### PR TITLE
WebPageTest custom metric

### DIFF
--- a/webpagetest/capo.js
+++ b/webpagetest/capo.js
@@ -1,0 +1,116 @@
+// Uncomment the following line when running this as a custom metric on webpagetest.org.
+//[capo]
+
+const WPT_BODIES = $WPT_BODIES;
+const RAW_HTML = WPT_BODIES[0].response_body;
+const RAW_DOCUMENT = document.implementation.createHTMLDocument('New Document');
+RAW_DOCUMENT.documentElement.innerHTML = RAW_HTML;
+
+const ElementWeights = {
+  META: 10,
+  TITLE: 9,
+  PRECONNECT: 8,
+  ASYNC_SCRIPT: 7,
+  IMPORT_STYLES: 6,
+  SYNC_SCRIPT: 5,
+  SYNC_STYLES: 4,
+  PRELOAD: 3,
+  DEFER_SCRIPT: 2,
+  PREFETCH_PRERENDER: 1,
+  OTHER: 0
+};
+
+const ElementDetectors = {
+  META: isMeta,
+  TITLE: isTitle,
+  PRECONNECT: isPreconnect,
+  ASYNC_SCRIPT: isAsyncScript,
+  IMPORT_STYLES: isImportStyles,
+  SYNC_SCRIPT: isSyncScript,
+  SYNC_STYLES: isSyncStyles,
+  PRELOAD: isPreload,
+  DEFER_SCRIPT: isDeferScript,
+  PREFETCH_PRERENDER: isPrefetchPrerender
+}
+
+
+function isMeta(element) {
+  return element.matches('meta:is([charset], [http-equiv], [name=viewport])');
+}
+
+function isTitle(element) {
+  return element.matches('title');
+}
+
+function isPreconnect(element) {
+  return element.matches('link[rel=preconnect]');
+}
+
+function isAsyncScript(element) {
+  return element.matches('script[async]');
+}
+
+function isImportStyles(element) {
+  const importRe = /@import/;
+
+  if (element.matches('style')) {
+    return importRe.test(element.textContent);
+  }
+
+  /* TODO: Support external stylesheets.
+  if (element.matches('link[rel=stylesheet][href]')) {
+    let response = fetch(element.href);
+    response = response.text();
+    return importRe.test(response);
+  } */
+
+  return false;
+}
+
+function isSyncScript(element) {
+  return element.matches('script:not([defer],[async],[type*=json])')
+}
+
+function isSyncStyles(element) {
+  return element.matches('link[rel=stylesheet],style');
+}
+
+function isPreload(element) {
+  return element.matches('link[rel=preload]');
+}
+
+function isDeferScript(element) {
+  return element.matches('script[defer]');
+}
+
+function isPrefetchPrerender(element) {
+  return element.matches('link:is([rel=prefetch], [rel=dns-prefetch], [rel=prerender])');
+}
+
+function stringifyElement(element) {
+  return element.getAttributeNames().reduce((id, attr) => id += `[${attr}="${element.getAttribute(attr)}"]`, element.nodeName);
+}
+
+function getWeight(element) {
+  for ([id, detector] of Object.entries(ElementDetectors)) {
+    if (detector(element)) {
+      return ElementWeights[id];
+    }
+  }
+
+  return ElementWeights.OTHER;
+}
+
+function visualizeWeight(weight) {
+  return new Array(weight + 1).fill('█').join('');
+}
+
+function getHeadWeights() {
+  const headChildren = Array.from(RAW_DOCUMENT.head.children);
+  return headChildren.map(element => {
+    const weight = getWeight(element);
+    return [visualizeWeight(weight), weight, stringifyElement(element)];
+  });
+}
+
+return JSON.stringify(getHeadWeights(), null, 2);


### PR DESCRIPTION
Tests

<details>
<summary>almanac.httparchive.org</summary>
Test: https://www.webpagetest.org/result/230521_BiDcBD_6Y6/1/details/
Results:

```
[
    "[\"███████████\",10,\"META[charset=\\\"UTF-8\\\"]\"]",
    "[\"███████████\",10,\"META[name=\\\"viewport\\\"][content=\\\"width=device-width, initial-scale=1\\\"]\"]",
    "[\"██████████\",9,\"TITLE\"]",
    "[\"█████\",4,\"LINK[rel=\\\"stylesheet\\\"][href=\\\"/static/css/normalize.css?v=3a712a3381a95c0a7b7c6ed3aa03b911\\\"]\"]",
    "[\"█████\",4,\"LINK[rel=\\\"stylesheet\\\"][href=\\\"/static/css/almanac.css?v=f05fef6658e217eccdc03ecada33e256\\\"]\"]",
    "[\"█████\",4,\"LINK[rel=\\\"stylesheet\\\"][href=\\\"/static/css/index.css?v=69e30c0abbe9bb2368e12e7e8779d421\\\"]\"]",
    "[\"████\",3,\"LINK[rel=\\\"preload\\\"][href=\\\"/static/fonts/Poppins-Light.woff2\\\"][as=\\\"font\\\"][type=\\\"font/woff2\\\"][crossorigin=\\\"\\\"]\"]",
    "[\"████\",3,\"LINK[rel=\\\"preload\\\"][href=\\\"/static/fonts/Lato-Regular.woff2\\\"][as=\\\"font\\\"][type=\\\"font/woff2\\\"][crossorigin=\\\"\\\"]\"]",
    "[\"████\",3,\"LINK[rel=\\\"preload\\\"][href=\\\"/static/fonts/Poppins-Bold.woff2\\\"][as=\\\"font\\\"][type=\\\"font/woff2\\\"][crossorigin=\\\"\\\"]\"]",
    "[\"████\",3,\"LINK[rel=\\\"preload\\\"][href=\\\"/static/fonts/Lato-Black.woff2\\\"][as=\\\"font\\\"][type=\\\"font/woff2\\\"][crossorigin=\\\"\\\"]\"]",
    "[\"████\",3,\"LINK[rel=\\\"preload\\\"][href=\\\"/static/fonts/Lato-Bold.woff2\\\"][as=\\\"font\\\"][type=\\\"font/woff2\\\"][crossorigin=\\\"\\\"]\"]",
    "[\"██████\",5,\"SCRIPT[nonce=\\\"hrOXpHAzo0MQdCYpDz0B4085cKO5EtIo\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"shortcut icon\\\"][href=\\\"/static/images/favicon.ico\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"apple-touch-icon\\\"][href=\\\"/static/images/apple-touch-icon.png\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"description\\\"][content=\\\"The Web Almanac is an annual state of the web report combining the expertise of the web community with the data and trends of the HTTP Archive.\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:title\\\"][content=\\\"The 2022 Web Almanac\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:url\\\"][content=\\\"https://almanac.httparchive.org/en/2022/\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:image\\\"][content=\\\"https://almanac.httparchive.org/static/images/home-hero-2022.png\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:image:height\\\"][content=\\\"600\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:image:width\\\"][content=\\\"1200\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:type\\\"][content=\\\"article\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"og:description\\\"][content=\\\"The Web Almanac is an annual state of the web report combining the expertise of the web community with the data and trends of the HTTP Archive.\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:card\\\"][content=\\\"summary_large_image\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:site\\\"][content=\\\"@HTTPArchive\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:title\\\"][content=\\\"The 2022 Web Almanac\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:image\\\"][content=\\\"https://almanac.httparchive.org/static/images/home-hero-2022.png\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:image:alt\\\"][content=\\\"The 2022 Web Almanac\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:description\\\"][content=\\\"The Web Almanac is an annual state of the web report combining the expertise of the web community with the data and trends of the HTTP Archive.\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"webmention\\\"][href=\\\"https://webmention.io/almanac.httparchive.org/webmention\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"pingback\\\"][href=\\\"https://webmention.io/almanac.httparchive.org/xmlrpc\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"me\\\"][href=\\\"mailto:team@httparchive.org\\\"]\"]",
    "[\"█\",0,\"SCRIPT[type=\\\"application/ld+json\\\"]\"]",
    "[\"█\",0,\"SCRIPT[type=\\\"application/ld+json\\\"]\"]",
    "[\"█\",0,\"SCRIPT[type=\\\"application/ld+json\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"canonical\\\"][href=\\\"https://almanac.httparchive.org/en/2022/\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][type=\\\"application/rss+xml\\\"][title=\\\"Web Almanac by HTTP Archive RSS (en)\\\"][href=\\\"/en/rss.xml\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/en/2022/\\\"][hreflang=\\\"en\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/es/2022/\\\"][hreflang=\\\"es\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/fr/2022/\\\"][hreflang=\\\"fr\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/hi/2022/\\\"][hreflang=\\\"hi\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/it/2022/\\\"][hreflang=\\\"it\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/ja/2022/\\\"][hreflang=\\\"ja\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/nl/2022/\\\"][hreflang=\\\"nl\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/pt/2022/\\\"][hreflang=\\\"pt\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/ru/2022/\\\"][hreflang=\\\"ru\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/tr/2022/\\\"][hreflang=\\\"tr\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/uk/2022/\\\"][hreflang=\\\"uk\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/zh-CN/2022/\\\"][hreflang=\\\"zh-CN\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/zh-TW/2022/\\\"][hreflang=\\\"zh-TW\\\"]\"]",
    "[\"█\",0,\"LINK[rel=\\\"alternate\\\"][href=\\\"https://almanac.httparchive.org/en/2022/\\\"][hreflang=\\\"x-default\\\"]\"]"
]
```
</details>

<details>
<summary>nytimes.com</summary>

Test: https://www.webpagetest.org/result/230521_BiDcJ1_75T/1/details/
Results:

```
[
    "[\"███████████\",10,\"META[charset=\\\"utf-8\\\"]\"]",
    "[\"██████████\",9,\"TITLE[data-rh=\\\"true\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"description\\\"][content=\\\"Live news, investigations, opinion, photos and video by the journalists of The New York Times from more than 150 countries around the world. Subscribe for coverage of U.S. and international news, politics, business, technology, science, health, arts, sports and more.\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][property=\\\"og:url\\\"][content=\\\"https://www.nytimes.com\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][property=\\\"og:type\\\"][content=\\\"website\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][property=\\\"og:title\\\"][content=\\\"The New York Times - Breaking News, US News, World News and Videos\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][property=\\\"og:description\\\"][content=\\\"Live news, investigations, opinion, photos and video by the journalists of The New York Times from more than 150 countries around the world. Subscribe for coverage of U.S. and international news, politics, business, technology, science, health, arts, sports and more.\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][property=\\\"og:image\\\"][content=\\\"https://static01.nyt.com/newsgraphics/images/icons/defaultPromoCrop.png\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"canonical\\\"][href=\\\"https://www.nytimes.com\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com\\\"][hreflang=\\\"x-default\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com\\\"][hreflang=\\\"en-US\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com/international/\\\"][hreflang=\\\"en\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com/international/\\\"][hreflang=\\\"en-GB\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com/international/\\\"][hreflang=\\\"en-AU\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com/ca/\\\"][hreflang=\\\"en-CA\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://www.nytimes.com/es/\\\"][hreflang=\\\"es\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://cn.nytimes.com\\\"][hreflang=\\\"zh-Hans\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][href=\\\"https://cn.nytimes.com/zh-hant/\\\"][hreflang=\\\"zh-Hant\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"alternate\\\"][type=\\\"application/rss+xml\\\"][title=\\\"RSS\\\"][href=\\\"https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml\\\"]\"]",
    "[\"█\",0,\"SCRIPT[data-rh=\\\"true\\\"][type=\\\"application/ld+json\\\"]\"]",
    "[\"█\",0,\"SCRIPT[data-rh=\\\"true\\\"][type=\\\"application/ld+json\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"application-name\\\"][content=\\\"The New York Times\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"msapplication-starturl\\\"][content=\\\"https://www.nytimes.com\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"msapplication-task\\\"][content=\\\"name=Search;action-uri=https://www.nytimes.com/search/?src=iepin;icon-uri=https://static01.nyt.com/images/icons/search.ico\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"msapplication-task\\\"][content=\\\"name=Most Popular;action-uri=https://www.nytimes.com/trending/?src=iepin;icon-uri=https://static01.nyt.com/images/icons/mostpopular.ico\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"msapplication-task\\\"][content=\\\"name=Video;action-uri=https://www.nytimes.com/video?src=iepin;icon-uri=https://static01.nyt.com/images/icons/video.ico\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"msapplication-task\\\"][content=\\\"name=Homepage;action-uri=https://www.nytimes.com?src=iepin&adxnnl=1;icon-uri=https://static01.nyt.com/images/icons/homepage.ico\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"nyt_uri\\\"][content=\\\"nyt://programmingnode/1999c500-b740-5ba9-b2c1-57ff6b183315\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"CG\\\"][content=\\\"Homepage\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"SCG\\\"][content=\\\"\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"PT\\\"][content=\\\"Homepage\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"PST\\\"][content=\\\"\\\"]\"]",
    "[\"█\",0,\"META[data-rh=\\\"true\\\"][name=\\\"keywords\\\"][content=\\\"news, live updates, latest news, breaking news, local news, current events, top stories, livestream, live video, world news, us news\\\"]\"]",
    "[\"███████████\",10,\"META[name=\\\"viewport\\\"][content=\\\"width=device-width, initial-scale=1\\\"]\"]",
    "[\"█\",0,\"META[property=\\\"fb:app_id\\\"][content=\\\"9869919170\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"twitter:site\\\"][content=\\\"@nytimes\\\"]\"]",
    "[\"█\",0,\"META[name=\\\"slack-app-id\\\"][content=\\\"A0121HXPPTQ\\\"]\"]",
    "[\"██████\",5,\"SCRIPT\"]",
    "[\"██████\",5,\"SCRIPT\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"shortcut icon\\\"][href=\\\"/vi-assets/static-assets/favicon-d2483f10ef688e6f89e23806b9700298.ico\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"apple-touch-icon\\\"][href=\\\"/vi-assets/static-assets/apple-touch-icon-28865b72953380a40aa43318108876cb.png\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"apple-touch-icon-precomposed\\\"][sizes=\\\"144×144\\\"][href=\\\"/vi-assets/static-assets/ios-ipad-144x144-28865b72953380a40aa43318108876cb.png\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"apple-touch-icon-precomposed\\\"][sizes=\\\"114×114\\\"][href=\\\"/vi-assets/static-assets/ios-iphone-114x144-080e7ec6514fdc62bcbb7966d9b257d2.png\\\"]\"]",
    "[\"█\",0,\"LINK[data-rh=\\\"true\\\"][rel=\\\"apple-touch-icon-precomposed\\\"][href=\\\"/vi-assets/static-assets/ios-default-homescreen-57x57-43808a4cd5333b648057a01624d84960.png\\\"]\"]",
    "[\"█████\",4,\"LINK[href=\\\"https://g1.nyt.com/fonts/css/web-fonts.7705b21d4573b168a8aaebc4ff17d395d2458dca.css\\\"][rel=\\\"stylesheet\\\"][type=\\\"text/css\\\"]\"]",
    "[\"█████\",4,\"LINK[rel=\\\"stylesheet\\\"][href=\\\"/vi-assets/static-assets/global-f449cfd9976ad673ef2b7ab5098b85be.css\\\"]\"]",
    "[\"█████\",4,\"STYLE\"]",
    "[\"█████\",4,\"STYLE[data-lights-css=\\\"0 1dv1kvn 1hyfx7x 8pe5zk 5wt1bj 1vlye70 ogiugu 9e9ivx hnzl8o stscvm 158f1cv wu78io 1y7qxpi 1llhclm cwdrld 1wjnrbv tmjxlh 1hd1ne6 1k9ek97 6n7j50 1fe7a5q kgn7zc 10488qs kdur8l 1e1s8k7 15uy5yv jq1cx6 17ih8de 79elbk 1ly73wi rfqw0c ki347z 1uk1gs8 122y91a 1ii2lp6 5qsr3h 1iubrw4 e5vw35 sxmela zirthl hdqqnp twl3ow 15rwwo 1wd5atx b8r4vz 1rr4qq7 o8apx3 142l3g4 le4k3i 1iruc8t uw59u jxzr5i oylsik qtw155 v0l3hm g4gku8 6xhk3s 1onhbft tj0ten ist4u3 1gprdgz 10t7hia e9w26l wbbhzv 1oyjjn8 1jmp9xk 6td9kr r5ic95 fzvsed 123u7tk tkwi90 nhjhh0 1ho5u4o 13o0c9t a7htku 1a5mdf6 1r6wvpq 1l41i6b 18spmoz ahe4g0 9kr9i3 qo6pn 8xdxq2 vktqhz 12bivf2 1oajkic 1ts4sjb bfvq22 1q2j1fr 397oyn 144qvsq pqd7q9 100xb1c 10gh44g 1u969e4 9mylee xdandi si8ren 197v62q 1azn4ub 1esztn 1xnr9ii ho9dtj 1p5yz2j 1j306sm 13htjwu v3yd4l 66vf3i oeful5 1o7p3um obze5b a92vur on97le dzl7b5 ikai89 wne2ji 1ozlsow f6ozty qnkhfn 1qa12lp 8iatcx ouupg9 1kpof33 155pfad b6n3ve 1wmsjvb 4dgob3 oz0kdv 8l3tpl 1gb49m4 rgq5s4 1hgbvll dgqyc1 ofn1hu 187m7gx 1rtvlp8 9dj29s l08pwh 1h1983p 1rlghcl 6v3ju5 1fvhbq8 2il6mf 1lel406 v5yrnk rx8ss6 wip3ve 1e408s2 17jnd0c 1qpxn73 j4dysj scopcd 1ey7yyn 1rwxdtx o29qoe 1sj4zvy 1stvlmo kpxlkr 1txq2hu 16lxk39 puv3k4 1k5swdl 17drwyv y3q9q4 12kq0ez 3kzcvh y7g724 name 5j8bii duration delay timing-function\\\"]\"]",
    "[\"██████\",5,\"SCRIPT[type=\\\"text/javascript\\\"]\"]",
    "[\"██████\",5,\"SCRIPT\"]",
    "[\"████████\",7,\"SCRIPT[async=\\\"\\\"][src=\\\"/vi-assets/static-assets/adslot-93262eb6a389112c48e5.js\\\"]\"]",
    "[\"██████\",5,\"SCRIPT[data-rh=\\\"true\\\"]\"]",
    "[\"██████\",5,\"SCRIPT[data-rh=\\\"true\\\"][id=\\\"als-svc\\\"]\"]",
    "[\"██████\",5,\"SCRIPT[data-rh=\\\"true\\\"][id=\\\"adslot-config\\\"]\"]"
]
```
</details>