### PR TITLE
🥣 BigQuery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ For applications that add lots of dynamic content to the `<head>` on the client,
 
 You can use the [`capo` WebPageTest custom metric](webpagetest/) to evaluate only the server-rendered HTML `<head>`. Note that because this approach doesn't output to the console, we lose the visualization.
 
+You can also use the [`httparchive.fn.CAPO`](bigquery/) function on BigQuery to process HTML response bodies in the HTTP Archive dataset. Similar to the WebPageTest approach, the output is very basic.
+
 Alternatively, you can use local overrides in DevTools to manually inject the capo.js script into the document so that it runs before anything else, eg the first child of `<body>`. Harry Roberts also has a nifty [video](https://www.youtube.com/watch?v=UOn0b5kn3jk) showing how to use this feature. This has some drawbacks as well, for example the inline script might be blocked by CSP.
 
 Another idea would be to use something like Cloudflare workers to inject the script into the HTML stream. To work around CSP issues, you can write the worker in such a way that it parses out the correct `nonce` and adds it to the inline script. _(Note: Not tested, but please share examples if you get it working! _😄_)_

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -4,31 +4,22 @@
 
 ## Usage
 
+<img width="1483" alt="Using capo on BigQuery" src="https://github.com/rviscomi/capo.js/assets/1120896/783b1787-210e-4c95-a2f5-1d551afae331">
+
 Pass the HTML response body to the `httparchive.fn.CAPO` function:
 
 ```sql
-WITH req AS (
-  SELECT
-    page,
-    response_body
-  FROM
-    `httparchive.all.requests` TABLESAMPLE SYSTEM (0.001 PERCENT)
-  WHERE
-    date = '2023-05-01' AND
-    client = 'desktop' AND
-    is_main_document
-  LIMIT
-    1
-)
-
 SELECT
   page,
-  vizWeight,
-  weight,
-  element
+  httparchive.fn.CAPO(response_body) AS capo
 FROM
-  req,
-  UNNEST(httparchive.fn.CAPO(response_body))
+  `httparchive.all.requests` TABLESAMPLE SYSTEM (0.001 PERCENT)
+WHERE
+  date = '2023-05-01' AND
+  client = 'desktop' AND
+  is_main_document
+LIMIT
+  1
 ```
 
 Results:
@@ -40,3 +31,31 @@ https://www.example.com/ | ███████████ | 10 | `<meta chars
 https://www.example.com/ | ███████████ | 10 | `<meta http-equiv="Content-type" content="text/html; charset=utf-8">`
 https://www.example.com/ | ███████████ | 10 | `<meta name="viewport" content="width=device-width, initial-scale=1">`
 https://www.example.com/ | █████ | 4 | `<style type="text/css">...</style>`
+
+## Testing
+
+If needed, you can pass arbitrary strings of HTML to the function on BigQuery without incurring any processing costs:
+
+```sql
+SELECT httparchive.fn.CAPO('''
+<html>
+  <head>
+    <title>Example</title>
+    <link rel="manifest" href="/manifest.json">
+    <style></style>
+    <script defer src="script.js"></script>
+    <meta charset="utf-8">
+  </head>
+</html>
+''')
+```
+
+Results:
+
+vizWeight | weight | element
+-- | -- | --
+██████████ | 9 | `<title>Example</title>`
+█ | 0 | `<link rel="manifest" href="/manifest.json">`
+█████ | 4 | `<style></style>`
+███ | 2 | `<script defer="" src="script.js"></script>`
+███████████ | 10 | `<meta charset="utf-8">`

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -1,0 +1,42 @@
+# Capo on BigQuery
+
+[capo.sql](./capo.sql) is a BigQuery function that uses [Cheerio](https://cheerio.js.org/) to parse the HTML response bodies in HTTP Archive.
+
+## Usage
+
+Pass the HTML response body to the `httparchive.fn.CAPO` function:
+
+```sql
+WITH req AS (
+  SELECT
+    page,
+    response_body
+  FROM
+    `httparchive.all.requests` TABLESAMPLE SYSTEM (0.001 PERCENT)
+  WHERE
+    date = '2023-05-01' AND
+    client = 'desktop' AND
+    is_main_document
+  LIMIT
+    1
+)
+
+SELECT
+  page,
+  vizWeight,
+  weight,
+  element
+FROM
+  req,
+  UNNEST(httparchive.fn.CAPO(response_body))
+```
+
+Results:
+
+page | vizWeight | weight | element
+-- | -- | -- | --
+https://www.example.com/ | ██████████ | 9 | `<title>Example Domain</title>`
+https://www.example.com/ | ███████████ | 10 | `<meta charset="utf-8">`
+https://www.example.com/ | ███████████ | 10 | `<meta http-equiv="Content-type" content="text/html; charset=utf-8">`
+https://www.example.com/ | ███████████ | 10 | `<meta name="viewport" content="width=device-width, initial-scale=1">`
+https://www.example.com/ | █████ | 4 | `<style type="text/css">...</style>`

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -1,12 +1,12 @@
 # Capo on BigQuery
 
-[capo.sql](./capo.sql) is a BigQuery function that uses [Cheerio](https://cheerio.js.org/) to parse the HTML response bodies in HTTP Archive.
+[capo.sql](./capo.sql) is a BigQuery function that uses [Cheerio](https://cheerio.js.org/) to parse strings of HTML.
 
 ## Usage
 
 <img width="1483" alt="Using capo on BigQuery" src="https://github.com/rviscomi/capo.js/assets/1120896/783b1787-210e-4c95-a2f5-1d551afae331">
 
-Pass the HTML response body to the `httparchive.fn.CAPO` function:
+To analyze pages in HTTP Archive, pass the HTML response body to the [`httparchive.fn.CAPO`](console.cloud.google.com/bigquery?ws=!1m5!1m4!6m3!1shttparchive!2sfn!3sCAPO) function:
 
 ```sql
 SELECT
@@ -31,6 +31,12 @@ https://www.example.com/ | ███████████ | 10 | `<meta chars
 https://www.example.com/ | ███████████ | 10 | `<meta http-equiv="Content-type" content="text/html; charset=utf-8">`
 https://www.example.com/ | ███████████ | 10 | `<meta name="viewport" content="width=device-width, initial-scale=1">`
 https://www.example.com/ | █████ | 4 | `<style type="text/css">...</style>`
+
+Note that the HTML for some pages might be so large that it causes UDF timeouts/OOMs. One workaround is to extract only the `<head>` content before passing it into the function:
+
+```sql
+httparchive.fn.CAPO(REGEXP_EXTRACT(response_body, r'(?i)(.*</head>)'))
+```
 
 ## Testing
 
@@ -59,3 +65,52 @@ vizWeight | weight | element
 █████ | 4 | `<style></style>`
 ███ | 2 | `<script defer="" src="script.js"></script>`
 ███████████ | 10 | `<meta charset="utf-8">`
+
+## Aggregate statistics
+
+Using [capo.sql](./capo.sql) it's possible to analyze the entire HTTP Archive corpus.
+
+Here's an example of counting the number of pages whose `<head>` starts with an element of a given weight:
+
+```sql
+WITH firstHeadElements AS (
+  SELECT
+    httparchive.fn.CAPO(REGEXP_EXTRACT(response_body, r'(?i)(.*</head>)'))[SAFE_OFFSET(0)] AS capo
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2023-05-01' AND
+    client = 'mobile' AND
+    is_main_document
+)
+
+SELECT
+  capo.weight,
+  COUNT(0) AS pages
+FROM
+  firstHeadElements
+WHERE
+  capo.weight IS NOT NULL
+GROUP BY
+  weight
+ORDER BY
+  weight DESC
+```
+
+Results:
+
+weight | pages
+-- | --
+10 | 800,752
+9 | 202,438
+8 | 30,555
+7 | 98,241
+6 | 14,210
+5 | 600,997
+4 | 1,546,590
+3 | 142,417
+2 | 85,653
+1 | 22,148
+0 | 1,211,124
+
+Not every page will necessarily have an element of weight 10 (META) but these results definitely show a suprisingly high number of sites that lead with lower weights like 4 (SYNC_STYLES) and 0 (OTHER).

--- a/bigquery/capo.sql
+++ b/bigquery/capo.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE FUNCTION httparchive.fn.CAPO(html STRING)
 RETURNS ARRAY<STRUCT<vizWeight STRING, weight INT64, element STRING>>
 LANGUAGE js
 OPTIONS (library = 'gs://httparchive/lib/cheerio.js') AS '''
+try {
 const $ = cheerio.load(html);
 
 const ElementWeights = {
@@ -105,4 +106,7 @@ return Array.from($('head > *')).map(element => {
     element: stringifyElement(element)
   };
 });
+} catch (e) {
+  return null;
+}
 ''';

--- a/bigquery/capo.sql
+++ b/bigquery/capo.sql
@@ -1,0 +1,108 @@
+CREATE OR REPLACE FUNCTION httparchive.fn.CAPO(html STRING)
+RETURNS ARRAY<STRUCT<vizWeight STRING, weight INT64, element STRING>>
+LANGUAGE js
+OPTIONS (library = 'gs://httparchive/lib/cheerio.js') AS '''
+const $ = cheerio.load(html);
+
+const ElementWeights = {
+  META: 10,
+  TITLE: 9,
+  PRECONNECT: 8,
+  ASYNC_SCRIPT: 7,
+  IMPORT_STYLES: 6,
+  SYNC_SCRIPT: 5,
+  SYNC_STYLES: 4,
+  PRELOAD: 3,
+  DEFER_SCRIPT: 2,
+  PREFETCH_PRERENDER: 1,
+  OTHER: 0
+};
+
+const ElementDetectors = {
+  META: isMeta,
+  TITLE: isTitle,
+  PRECONNECT: isPreconnect,
+  ASYNC_SCRIPT: isAsyncScript,
+  IMPORT_STYLES: isImportStyles,
+  SYNC_SCRIPT: isSyncScript,
+  SYNC_STYLES: isSyncStyles,
+  PRELOAD: isPreload,
+  DEFER_SCRIPT: isDeferScript,
+  PREFETCH_PRERENDER: isPrefetchPrerender
+}
+
+
+function isMeta(element) {
+  return $(element).is('meta:is([charset], [http-equiv], [name=viewport])');
+}
+
+function isTitle(element) {
+  return $(element).is('title');
+}
+
+function isPreconnect(element) {
+  return $(element).is('link[rel=preconnect]');
+}
+
+function isAsyncScript(element) {
+  return $(element).is('script[async]');
+}
+
+function isImportStyles(element) {
+  const importRe = /@import/;
+
+  if ($(element).is('style')) {
+    return importRe.test($(element).text());
+  }
+
+  // TODO: Support external stylesheets.
+  return false;
+}
+
+function isSyncScript(element) {
+  return $(element).is('script:not([defer],[async],[type*=json])')
+}
+
+function isSyncStyles(element) {
+  return $(element).is('link[rel=stylesheet],style');
+}
+
+function isPreload(element) {
+  return $(element).is('link[rel=preload]');
+}
+
+function isDeferScript(element) {
+  return $(element).is('script[defer]');
+}
+
+function isPrefetchPrerender(element) {
+  return $(element).is('link:is([rel=prefetch], [rel=dns-prefetch], [rel=prerender])');
+}
+
+function stringifyElement(element) {
+  return $(element).toString();
+}
+
+function getWeight(element) {
+  for ([id, detector] of Object.entries(ElementDetectors)) {
+    if (detector(element)) {
+      return ElementWeights[id];
+    }
+  }
+
+  return ElementWeights.OTHER;
+}
+
+function visualizeWeight(weight) {
+  return new Array(weight + 1).fill('█').join('');
+}
+
+return Array.from($('head > *')).map(element => {
+  const weight = getWeight(element);
+  return {
+    vizWeight: visualizeWeight(weight),
+    weight,
+    element: stringifyElement(element)
+  };
+});
+''';


### PR DESCRIPTION
After some testing, it's possible to parse HTML within a BigQuery UDF, using [Cheerio](https://cheerio.js.org/). This PR implements capo.js into a BigQuery UDF with Cheerio methods instead of DOM methods. See the README for more info.