### PR TITLE
Only consider external async/defer scripts

### DIFF
--- a/bigquery/capo.sql
+++ b/bigquery/capo.sql
@@ -46,7 +46,7 @@ function isPreconnect(element) {
 }
 
 function isAsyncScript(element) {
-  return $(element).is('script[async]');
+  return $(element).is('script[src][async]');
 }
 
 function isImportStyles(element) {
@@ -73,7 +73,7 @@ function isPreload(element) {
 }
 
 function isDeferScript(element) {
-  return $(element).is('script[defer]');
+  return $(element).is('script[src][defer]');
 }
 
 function isPrefetchPrerender(element) {

--- a/capo.js
+++ b/capo.js
@@ -54,7 +54,7 @@ function isPreconnect(element) {
 }
 
 function isAsyncScript(element) {
-  return element.matches('script[async]');
+  return element.matches('script[src][async]');
 }
 
 function isImportStyles(element) {
@@ -87,7 +87,7 @@ function isPreload(element) {
 }
 
 function isDeferScript(element) {
-  return element.matches('script[defer]');
+  return element.matches('script[src][defer]');
 }
 
 function isPrefetchPrerender(element) {

--- a/webpagetest/capo.js
+++ b/webpagetest/capo.js
@@ -46,7 +46,7 @@ function isPreconnect(element) {
 }
 
 function isAsyncScript(element) {
-  return element.matches('script[async]');
+  return element.matches('script[src][async]');
 }
 
 function isImportStyles(element) {
@@ -81,7 +81,7 @@ function isPreload(element) {
 }
 
 function isDeferScript(element) {
-  return element.matches('script[defer]');
+  return element.matches('script[src][defer]');
 }
 
 function isPrefetchPrerender(element) {


### PR DESCRIPTION
`async` and `defer` attributes on inline script blocks are no-ops and shouldn't be counted as async/defer scripts. Look for the `src` attribute to indicate that it's an external script.