### PR TITLE
Only ignore `async`/`defer` for sync scripts when the `src` attr is present

### DIFF
--- a/bigquery/capo.sql
+++ b/bigquery/capo.sql
@@ -61,7 +61,7 @@ function isImportStyles(element) {
 }
 
 function isSyncScript(element) {
-  return $(element).is('script:not([defer],[async],[type*=json])')
+  return $(element).is('script:not([src][defer],[src][async],[type*=json])')
 }
 
 function isSyncStyles(element) {

--- a/capo.js
+++ b/capo.js
@@ -75,7 +75,7 @@ function isImportStyles(element) {
 }
 
 function isSyncScript(element) {
-  return element.matches('script:not([defer],[async],[type*=json])')
+  return element.matches('script:not([src][defer],[src][async],[type*=json])')
 }
 
 function isSyncStyles(element) {

--- a/webpagetest/capo.js
+++ b/webpagetest/capo.js
@@ -69,7 +69,7 @@ function isImportStyles(element) {
 }
 
 function isSyncScript(element) {
-  return element.matches('script:not([defer],[async],[type*=json])')
+  return element.matches('script:not([src][defer],[src][async],[type*=json])')
 }
 
 function isSyncStyles(element) {


### PR DESCRIPTION
Merged #12 too soon. The sync script check should still match scripts with `async` or `defer` as long as the `src` attribute is missing.