### PR TITLE
Handle `modulepreload`

### DIFF
--- a/capo.js
+++ b/capo.js
@@ -83,7 +83,7 @@ function isSyncStyles(element) {
 }
 
 function isPreload(element) {
-  return element.matches('link[rel=preload]');
+  return element.matches('link:is([rel=preload], [rel=modulepreload])');
 }
 
 function isDeferScript(element) {


### PR DESCRIPTION
Handle [`modulepreload`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload) as another flavor of `preload`