### PR TITLE
Discourage meta CSP

### DIFF
--- a/capo.js
+++ b/capo.js
@@ -314,9 +314,9 @@ function isValidElement(element) {
   if (element.matches('base:is(:nth-of-type(n+2))')) {
     return false;
   }
-
-  // CSP meta tag comes after a script.
-  if (element.matches('script ~ meta[http-equiv="Content-Security-Policy" i]')) {
+  
+  // CSP meta tag anywhere.
+  if (element.matches('meta[http-equiv="Content-Security-Policy" i]')) {
     return false;
   }
 
@@ -335,10 +335,10 @@ function validateHead() {
   if (baseElementCount > 1) {
     console.warn(`${LOGGING_PREFIX}Expected at most 1 <base> element, found ${baseElementCount}`, baseElements);
   }
-
-  const postScriptCSP = head.querySelector('script ~ meta[http-equiv="Content-Security-Policy" i]');
-  if (postScriptCSP) {
-    console.warn(`${LOGGING_PREFIX}CSP meta tag must be placed before any <script> elements to avoid disabling the preload scanner.`, getLoggableElement(postScriptCSP));
+  
+  const metaCSP = head.querySelector('meta[http-equiv="Content-Security-Policy" i]');
+  if (metaCSP) {
+    console.warn(`${LOGGING_PREFIX}CSP meta tags disable the preload scanner due to a bug in Chrome. Use the CSP header instead. Learn more: https://crbug.com/1458493`, getLoggableElement(metaCSP));
   }
 
   if (!isStaticHead) {

--- a/capo.js
+++ b/capo.js
@@ -143,6 +143,10 @@ function isOriginTrial(element) {
   return element.matches('meta[http-equiv="origin-trial"i]');
 }
 
+function isMetaCSP(element) {
+  return element.matches('meta[http-equiv="Content-Security-Policy" i]');
+}
+
 function getWeight(element) {
   for ([id, detector] of Object.entries(ElementDetectors)) {
     if (detector(element)) {
@@ -234,7 +238,10 @@ function logElement({viz, weight, element, isValid, omitPrefix = false}) {
   let loggingLevel = 'log';
   const args = [viz.visual, viz.style, weight + 1, element];
 
-  if (isStaticHead && !isValid) {
+  if (isMetaCSP(element)) {
+    loggingLevel = 'warn';
+    args.push('❌ meta CSP discouraged. See https://crbug.com/1458493.')
+  } else if (isStaticHead && !isValid) {
     loggingLevel = 'warn';
     args.push('❌ invalid element');
   }
@@ -316,7 +323,7 @@ function isValidElement(element) {
   }
   
   // CSP meta tag anywhere.
-  if (element.matches('meta[http-equiv="Content-Security-Policy" i]')) {
+  if (isMetaCSP(element)) {
     return false;
   }
 

--- a/crx/capo.js
+++ b/crx/capo.js
@@ -200,6 +200,10 @@ async function capo({fn, args}={}) {
   function isOriginTrial(element) {
     return element.matches('meta[http-equiv="origin-trial"i]');
   }
+
+  function isMetaCSP(element) {
+    return element.matches('meta[http-equiv="Content-Security-Policy" i]');
+  }
   
   function getWeight(element) {
     for ([id, detector] of Object.entries(ElementDetectors)) {
@@ -257,7 +261,11 @@ async function capo({fn, args}={}) {
     let loggingLevel = 'log';
     const args = [viz.visual, viz.style, weight + 1, element];
 
-    if (isStaticHead && !isValid) {
+
+    if (isMetaCSP(element)) {
+      loggingLevel = 'warn';
+      args.push('❌ meta CSP discouraged. See https://crbug.com/1458493.')
+    } else if (isStaticHead && !isValid) {
       loggingLevel = 'warn';
       args.push('❌ invalid element');
     }
@@ -406,8 +414,8 @@ async function capo({fn, args}={}) {
       return false;
     }
   
-    // CSP meta tag comes after a script.
-    if (element.matches('script ~ meta[http-equiv="Content-Security-Policy" i]')) {
+    // CSP meta tag anywhere.
+    if (isMetaCSP(element)) {
       return false;
     }
   
@@ -427,9 +435,9 @@ async function capo({fn, args}={}) {
       console.warn(`${LOGGING_PREFIX}Expected at most 1 <base> element, found ${baseElementCount}`, baseElements);
     }
   
-    const postScriptCSP = head.querySelector('script ~ meta[http-equiv="Content-Security-Policy" i]');
-    if (postScriptCSP) {
-      console.warn(`${LOGGING_PREFIX}CSP meta tag must be placed before any <script> elements to avoid disabling the preload scanner.`, getLoggableElement(postScriptCSP));
+    const metaCSP = head.querySelector('meta[http-equiv="Content-Security-Policy" i]');
+    if (metaCSP) {
+      console.warn(`${LOGGING_PREFIX}CSP meta tags disable the preload scanner due to a bug in Chrome. Use the CSP header instead. Learn more: https://crbug.com/1458493`, getLoggableElement(metaCSP));
     }
   
     if (!isStaticHead) {

--- a/crx/manifest.json
+++ b/crx/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Capo: get your ﹤𝚑𝚎𝚊𝚍﹥ in order",
   "description": "Visualize the optimal ordering of ﹤𝚑𝚎𝚊𝚍﹥ elements on any web page",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "permissions": [
     "scripting",
     "activeTab"


### PR DESCRIPTION
Given the recent discovery of a [bug](https://crbug.com/1458493) in Chrome in which _any_ meta CSP causes the preload scanner to stop, this PR expands the validator to consider all meta CSPs as "invalid" with a warning to discourage their use. Highly opinionated, but worth flagging.

<img width="1426" alt="image" src="https://github.com/rviscomi/capo.js/assets/1120896/d7de1b91-3266-4cb9-8bae-2e4bcd8b4567">
