### PR TITLE
Better error handling for the URL demo

### DIFF
--- a/docs/src/components/CapoClient.astro
+++ b/docs/src/components/CapoClient.astro
@@ -23,11 +23,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     virtualConsole = new VirtualConsole(output);
 
     input.addEventListener('submit', e => {
-      try {
-        handleSubmit();
-      } catch (e) {
-        console.error('Capo error', e);
-      }
+      handleSubmit();
       e.preventDefault();
       return false;
     });
@@ -89,6 +85,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     const proxy = new URL('https://capo.rviscomi.workers.dev/');
     proxy.searchParams.set('url', url);
     const response = await fetch(proxy);
+    if (response.status == 502) {
+      throw new Error(`502 Gateway Error. The URL ${url} cannot be fetched. (Possibly too many redirects)`);
+    } else if (!response.ok) {
+      throw new Error('Unknown error fetching the URL. Please file an issue: https://github.com/rviscomi/capo.js/issues/');
+    }
     return await response.text();
   }
 </script>


### PR DESCRIPTION
https://twitter.com breaks the proxy. It does a 302 redirect to itself. Visiting in a browser doesn't have a redirect loop somehow, but fetching from the server side does.

https://rviscomi.github.io/capo.js/user/demo/?url=https%3A%2F%2Ftwitter.com

The client script will happily attempt to parse the empty response, so this fix immediately throws an error for the special HTTP 502 in response to this edge case as well as any other unexpected errors.