### PR TITLE
Link extension options page to extension docs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleAttributePerLine": false,
+  "printWidth": 120
+}

--- a/crx/manifest.json
+++ b/crx/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Capo: get your ﹤𝚑𝚎𝚊𝚍﹥ in order",
   "description": "Visualize the optimal ordering of ﹤𝚑𝚎𝚊𝚍﹥ elements on any web page",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "permissions": [
     "scripting",
     "activeTab",

--- a/crx/options/options.html
+++ b/crx/options/options.html
@@ -2,35 +2,40 @@
 <html>
   <head>
     <title>Capo Options</title>
-    <link rel="stylesheet" href="../styles/open-props.css">
-    <link rel="stylesheet" href="options.css">
+    <link rel="stylesheet" href="../styles/open-props.css" />
+    <link rel="stylesheet" href="options.css" />
   </head>
   <body class="surface-1">
     <form id="options">
       <header>
         <h1>Capo options</h1>
       </header>
-      <input id="prefer-static" name="prefer-static" type="checkbox" class="option">
+      <input id="prefer-static" name="prefer-static" type="checkbox" class="option" />
       <label for="prefer-static">
-        Prefer to evaluate the static, server-rendered <code>&lt;head></code>
-        (<a href="https://rviscomi.github.io/capo.js/user/config/#static-and-dynamic-evaluation">learn more</a>)
+        Prefer to evaluate the static, server-rendered
+        <code>&lt;head></code> (<a href="https://rviscomi.github.io/capo.js/user/config/#static-and-dynamic-evaluation"
+          >learn more</a
+        >)
       </label>
 
-      <input id="validation" name="validation" type="checkbox" class="option">
+      <input id="validation" name="validation" type="checkbox" class="option" />
       <label for="validation">
-        Validate the elements in the <code>&lt;head></code>
-        (<a href="https://rviscomi.github.io/capo.js/user/config/#validation">learn more</a>)
+        Validate the elements in the <code>&lt;head></code> (<a
+          href="https://rviscomi.github.io/capo.js/user/config/#validation"
+          >learn more</a
+        >)
       </label>
 
       <select id="palette" name="palette" class="option"></select>
       <label for="palette">
-        Color palette
-        (<a href="https://rviscomi.github.io/capo.js/user/config/#built-in-color-palettes">learn more</a>)
+        Color palette (<a href="https://rviscomi.github.io/capo.js/user/config/#built-in-color-palettes">learn more</a>)
       </label>
 
       <footer>
         <p>Options saved automatically</p>
-        <p><a href="https://rviscomi.github.io/capo.js/">rviscomi/capo.js</a></p>
+        <p>
+          <a href="https://rviscomi.github.io/capo.js/user/extension/">rviscomi/capo.js</a>
+        </p>
       </footer>
     </form>
     <script src="options.js" type="module"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rviscomi/capo.js",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Get your ﹤𝚑𝚎𝚊𝚍﹥ in order",
   "author": "Rick Viscomi",
   "license": "Apache-2.0",


### PR DESCRIPTION
The footer of the extension options page links to the docs home page. Since we have [extension-specific docs](https://rviscomi.github.io/capo.js/user/extension/), let's link there directly.

<img width="722" alt="image" src="https://github.com/rviscomi/capo.js/assets/1120896/a961e6aa-d8e4-4af6-bd33-5ebd196e7ef7">
